### PR TITLE
fix: wrap useSearchParams in Suspense boundary

### DIFF
--- a/src/app/payment-success/PaymentSuccessWrapper.tsx
+++ b/src/app/payment-success/PaymentSuccessWrapper.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import PaymentSuccessPage from "@/components/PaymentSuccessPage";
+import { useSearchParams } from "next/navigation";
+
+export default function PaymentSuccessWrapper() {
+  const searchParams = useSearchParams();
+  const payment_intent = searchParams.get("payment_intent") || "";
+
+  return <PaymentSuccessPage payment_intent={payment_intent} />;
+}

--- a/src/app/payment-success/page.tsx
+++ b/src/app/payment-success/page.tsx
@@ -1,11 +1,16 @@
-"use client";
-
-import PaymentSuccessPage from "@/components/PaymentSuccessPage";
-import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import PaymentSuccessWrapper from "./PaymentSuccessWrapper";
 
 export default function PaymentSuccess() {
-  const searchParams = useSearchParams();
-  const payment_intent = searchParams.get("payment_intent") || "";
-
-  return <PaymentSuccessPage payment_intent={payment_intent} />;
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center min-h-screen">
+          <p className="text-muted-foreground">Loading payment details...</p>
+        </div>
+      }
+    >
+      <PaymentSuccessWrapper />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
Next.js 16 requires useSearchParams() inside a Suspense boundary for static generation.

Changes:
- Extracted useSearchParams logic into PaymentSuccessWrapper client component
- Wrapped in Suspense in page.tsx (now a server component)